### PR TITLE
Sort plugin list by downloads by default

### DIFF
--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -68,6 +68,8 @@ export function filterPlugins(router: NextRouter, packages: RegistryPackages) {
     }
   }
   return packagesFiltered.sort((a: PackageInterface, b: PackageInterface) => {
+    const downloadsDiff = (b.downloads || 0) - (a.downloads || 0);
+    if (downloadsDiff !== 0) return downloadsDiff;
     return a.versions[a.version].name.localeCompare(b.versions[b.version].name);
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@open-audio-stack/core": "^0.1.50",
+        "@open-audio-stack/core": "^0.1.55",
         "gray-matter": "^4.0.3",
         "next": "^16.1.6",
         "react": "^18.3.1",
@@ -2117,14 +2117,14 @@
       }
     },
     "node_modules/@open-audio-stack/core": {
-      "version": "0.1.50",
-      "resolved": "https://registry.npmjs.org/@open-audio-stack/core/-/core-0.1.50.tgz",
-      "integrity": "sha512-WunmkEbmf9532KKIiPzWropqBTVAgOAPOUUQh901IesmcSsvJXYYdvYG3Y10p8my1/CnAy1zpqAmdf5drgQzUA==",
+      "version": "0.1.55",
+      "resolved": "https://registry.npmjs.org/@open-audio-stack/core/-/core-0.1.55.tgz",
+      "integrity": "sha512-BknnVWbBRUj0m64cVAG7nEuJkDu6PINki2s8RkAU2ylRk/L1vJHYM7ftQktulMZ91Pz3pCBhbrWAGcObiD6Rhg==",
       "license": "cc0-1.0",
       "dependencies": {
         "@vscode/sudo-prompt": "^9.3.1",
         "7zip-min": "^1.4.5",
-        "adm-zip": "^0.5.16",
+        "adm-zip": "^0.6.0",
         "chalk": "^5.3.0",
         "fs-extra": "^11.2.0",
         "glob": "^11.0.0",
@@ -2138,15 +2138,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@open-audio-stack/core/node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0"
       }
     },
     "node_modules/@open-audio-stack/core/node_modules/chalk": {
@@ -3211,6 +3202,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@open-audio-stack/core": "^0.1.50",
+    "@open-audio-stack/core": "^0.1.55",
     "gray-matter": "^4.0.3",
     "next": "^16.1.6",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary
- Upgrades `@open-audio-stack/core` to `0.1.55` to consume the new per-package `downloads` rollup field (GitHub release download counts, aggregated file → version → package).
- Changes `filterPlugins()`'s default sort in `lib/plugin.ts` from alphabetical-by-name to most-downloaded-first, falling back to name for ties or packages with no download data (e.g. non-GitHub-hosted packages).
- Same default sort is being applied identically in `studiorack-app` and `studiorack-cli` (separate PRs), so plugin lists rank consistently across all three surfaces.

## Test plan
- [x] `npm run build` — succeeds, all plugin/preset/project pages statically generate
- [x] `npm run lint` — clean
- [x] `npm test` — 1/1 passing
- [x] Verified locally via `npm run dev` that `/plugins` renders and lists most-downloaded packages first

🤖 Generated with [Claude Code](https://claude.com/claude-code)