### PR TITLE
fix: missing key prop warning in MultiSelect

### DIFF
--- a/components/multi-select.tsx
+++ b/components/multi-select.tsx
@@ -62,7 +62,7 @@ const MultiSelect = ({ label, items }: MultiSelectProps) => {
       </select>
       <div className={styles.multiselectCheckboxes} id={label}>
         {items.map(item => (
-          <div className={styles.multiselectCheckbox}>
+          <div className={styles.multiselectCheckbox} key={toSlug(item.value)}>
             <input
               className={styles.multiselectInput}
               type="checkbox"
@@ -71,12 +71,7 @@ const MultiSelect = ({ label, items }: MultiSelectProps) => {
               onClick={updateUrl}
               defaultChecked={isChecked(item.value)}
             />
-            <label
-              className={styles.multiselectLabel}
-              htmlFor={toSlug(item.value)}
-              key={toSlug(item.value)}
-              title={item.name}
-            >
+            <label className={styles.multiselectLabel} htmlFor={toSlug(item.value)} title={item.name}>
               {item.name}
             </label>
           </div>


### PR DESCRIPTION
## Summary
- React was warning "Each child in a list should have a unique key prop" in `MultiSelect` — the `key` was set on the nested `<label>` instead of the outer `<div>` returned by `.map()`
- Moved `key` to the top-level mapped element

## Test plan
- [x] `npm run lint` passes
- [x] `npm run dev` — warning no longer appears on `/plugins`

🤖 Generated with [Claude Code](https://claude.com/claude-code)