### PR TITLE
fix: move Google Fonts stylesheet to _document to remove Next.js warning

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -19,10 +19,6 @@ const Layout = ({ children }: LayoutProps) => (
       <meta name="og:image" content={`${getBasePath()}/images/creators-mobile.jpg`} />
       <meta name="og:title" content={siteTitle} />
       <meta name="twitter:card" content="summary_large_image" />
-      <link
-        href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&amp;display=swap"
-        rel="stylesheet"
-      ></link>
       <link rel="apple-touch-icon" sizes="180x180" href={`${getBasePath()}/icons/apple-touch-icon.png`} />
       <link rel="icon" type="image/png" sizes="32x32" href={`${getBasePath()}/icons/favicon-32x32.png`} />
       <link rel="icon" type="image/png" sizes="16x16" href={`${getBasePath()}/icons/favicon-16x16.png`} />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,20 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+const Document = () => (
+  <Html lang="en">
+    <Head>
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&amp;display=swap"
+        rel="stylesheet"
+      />
+    </Head>
+    <body>
+      <Main />
+      <NextScript />
+    </body>
+  </Html>
+);
+
+export default Document;


### PR DESCRIPTION
## Summary
- Next.js/Turbopack was warning on every page load: `Do not add stylesheets using next/head ... Use Document instead.` This came from the Google Fonts `<link rel="stylesheet">` rendered inside `Layout`'s `next/head` block, since `next/head` re-renders per page and can duplicate stylesheet links on client-side navigation.
- Added `pages/_document.tsx` (previously missing) and moved the Google Fonts stylesheet link there, along with `preconnect` hints for `fonts.googleapis.com`/`fonts.gstatic.com` as recommended in the [Next.js docs](https://nextjs.org/docs/messages/no-stylesheets-in-head-component).
- Removed the stylesheet link from `components/layout.tsx`; the rest of that `Head` (title, meta tags, favicons) is left as-is since those are fine to be per-page.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint pages/_document.tsx components/layout.tsx` passes
- [x] Ran `npm run dev` and loaded `/` and `/plugins` — the "Do not add stylesheets using next/head" warning no longer appears in server or browser console
- [x] Roboto font still loads correctly (visually verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)