### PR TITLE
feat: default System filter to the visitor's detected OS

### DIFF
--- a/components/filters.tsx
+++ b/components/filters.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import styles from '../styles/components/filters.module.css';
 import MultiSelect from './multi-select';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import {
   licenses,
   pluginCategoryInstruments,
@@ -17,6 +17,7 @@ import {
 } from '@open-audio-stack/core';
 import { pluginCategoryEffects } from '@open-audio-stack/core';
 import { getParam } from '../lib/plugin';
+import { detectSystemType } from '../lib/system';
 
 type FiltersProps = {
   section: RegistryType;
@@ -27,6 +28,15 @@ const FILTER_KEYS = ['type', 'category', 'system', 'license', 'search'];
 const Filters = ({ section }: FiltersProps) => {
   const router = useRouter();
   const [openFilter, setOpenFilter] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!router.isReady || router.query.system) return;
+    const detected = detectSystemType();
+    if (detected) {
+      router.replace({ pathname: router.pathname, query: { ...router.query, system: detected } });
+    }
+  }, [router.isReady]);
+
   const type = getParam(router, 'type');
   const search = getParam(router, 'search');
   let categories: PluginCategoryOption[] | ProjectFormatOption[] =

--- a/lib/system.ts
+++ b/lib/system.ts
@@ -1,0 +1,12 @@
+import { SystemType } from '@open-audio-stack/core';
+
+export function detectSystemType(): SystemType | undefined {
+  if (typeof navigator === 'undefined') return undefined;
+  const uaData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData;
+  const source = (uaData?.platform || navigator.platform || navigator.userAgent || '').toLowerCase();
+  if (source.includes('android') || source.includes('iphone')) return undefined;
+  if (source.includes('mac')) return SystemType.Mac;
+  if (source.includes('win')) return SystemType.Win;
+  if (source.includes('linux')) return SystemType.Linux;
+  return undefined;
+}


### PR DESCRIPTION
Most people only care about plugins for the platform they're actually on. On first load (no explicit ?system= param in the URL), detect the OS via navigator.userAgentData.platform (falling back to the deprecated navigator.platform / userAgent for browsers without Client Hints) and pre-select the matching System filter via router.replace, so it doesn't add a history entry. Mobile UAs are left undetected since desktop plugin formats aren't relevant there.

An explicit ?system= in the URL (shared link, or the user having already changed it this session) is left untouched, and the effect only runs once per page mount, so clearing the filter doesn't cause it to immediately reapply.